### PR TITLE
Pin `rspec` to `~>3.3`

### DIFF
--- a/krikri-spec.gemspec
+++ b/krikri-spec.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'krikri'
+  s.add_dependency 'rspec',  '~> 3.3'
 
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'rspec', '~> 3.2'
 end


### PR DESCRIPTION
Bumps the RSpec version to 3.3 to match KriKri. This is related to:
http://rspec.info/blog/2015/06/rspec-3-3-has-been-released/ and
https://github.com/dpla/KriKri/pull/243

Makes RSpec a runtime dependency to force this version requirement on
apps using this gem. Because those apps should make this gem a
development dependency, the requirement won't affect their runtime
dependencies.
