### PR TITLE
Use KriKri as a development dependency

### DIFF
--- a/krikri-spec.gemspec
+++ b/krikri-spec.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'krikri'
   s.add_dependency 'rspec',  '~> 3.3'
 
+  s.add_development_dependency 'krikri'
   s.add_development_dependency 'yard'
 end


### PR DESCRIPTION
Making KriKri a runtime dependency leads to oddly circular resolutions in Bundler if the downstream app (`heidrun`) points to a local version.
